### PR TITLE
Adding Solidity Summit section and fixing links

### DIFF
--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -1,0 +1,3 @@
+<div class="video_wrapper">
+<iframe width="560" height="315" src="https://www.youtube.com/embed/{{ include.youtube_id}}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>

--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -1,3 +1,3 @@
 <div class="video_wrapper">
-<iframe width="560" height="315" src="https://www.youtube.com/embed/{{ include.youtube_id}}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/{{ include.youtube_id}}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -94,6 +94,21 @@ header {
 	position: relative;
 }
 
+.video_wrapper {
+	position: relative;
+	padding-bottom: 56.25%;
+	padding-top: 25px;
+	height: 0;
+}
+
+.video_wrapper iframe {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}
+
 section {
 	padding: 100px 0;
 }

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ description: All you need to know about Solidity in one place
 		<div class="container flex">
 			<div class="text editable">
 				<h2>Solidity is a statically-typed curly-braces programming language designed for developing smart contracts that run on <a href="https://ethereum.org/en/">Ethereum</a>.</h2>
-				<div class="cta button alt"><a href="https://solidity.readthedocs.io/en/latest/index.html#getting-started">get started</a></div>
+				<div class="cta button alt"><a href="https://docs.soliditylang.org/en/latest/index.html#getting-started">get started</a></div>
 			</div>
 			<img src="{{ site.baseurl }}/images/SolBlueGradient.png" alt="Solidity Logo" class="small-image"/>
 		</div>
@@ -30,7 +30,7 @@ description: All you need to know about Solidity in one place
 		<div class="text editable">
 			<h2><strong>Solidity is evolving rapidly.</strong></h2>
 			<p>As a relatively young language, Solidity is advancing at a rapid speed. We aim for a regular (non-breaking) release every 2-3 weeks, with approximately two breaking releases per year. You can follow the implementation status of new features in the <a href="https://github.com/ethereum/solidity/projects/43">Solidity Github project</a>. You can
-			see the upcoming changes for the next breaking release by switching from the default branch (`develop`) to the <a href="https://github.com/ethereum/solidity/tree/breaking">`breaking branch`</a>. You can actively shape Solidity by providing your input and participating in the <a href="https://solidity.readthedocs.io/en/latest/contributing.html">language design</a>.</p>
+			see the upcoming changes for the next breaking release by switching from the default branch (`develop`) to the <a href="https://github.com/ethereum/solidity/tree/breaking">`breaking branch`</a>. You can actively shape Solidity by providing your input and participating in the <a href="https://docs.soliditylang.org/en/latest/contributing.html">language design</a>.</p>
 		</div>
 	</div>
 </section>
@@ -39,13 +39,13 @@ description: All you need to know about Solidity in one place
 	<section>
 		<div class="container flex">
 			<div class="text editable">
-				<h2><strong>Stay always up-to-date by following the <a href="https://solidity.ethereum.org">Solidity blog</a> and the <a href="https://twitter.com/solidity_lang">Solidity Twitter</a>.</strong></h2>
+				<h2><strong>Stay always up-to-date by following the <a href="https://blog.soliditylang.org">Solidity blog</a> and the <a href="https://twitter.com/solidity_lang">Solidity Twitter</a>.</strong></h2>
 				<p>Recent news include:</p>
 				<ul>
-					<li><p>Solidity v0.8.x is coming soon! Have a look at the <a href="https://solidity.ethereum.org/2020/10/28/solidity-0.8.x-preview/">preview release post</a>, which includes preview binaries for testing.</li></p>
-					<li><p>Solidity v0.7.0 is out! Check out <a href="https://solidity.readthedocs.io/en/latest/070-breaking-changes.html#how-to-update-your-code">this guide</a> on how to best update your code to Solidity v0.7.x.</li></p>
+					<li><p>Solidity v0.8.x is coming soon! Have a look at the <a href="https://blog.soliditylang.org/2020/10/28/solidity-0.8.x-preview/">preview release post</a>, which includes preview binaries for testing.</li></p>
+					<li><p>Solidity v0.7.0 is out! Check out <a href="https://docs.soliditylang.org/en/latest/070-breaking-changes.html#how-to-update-your-code">this guide</a> on how to best update your code to Solidity v0.7.x.</li></p>
 					<li><p>The infamous Solidity Underhanded Contest is back. This year's task is to create a seamingly safe upgrade mechanism which contains backdoors. Submissions close on Oct 31. Visit the <a href="https://underhanded.soliditylang.org/">contest website</a> for all details!</li></p>
-					<li><p>Lastest from the blog: <a href="https://solidity.ethereum.org/2020/09/18/meet-the-team/">Meet the Solidity team!</a> - short interviews with some of the core team members and <a href="https://solidity.ethereum.org/2020/11/04/solidity-ama-1-recap/">Solidity AMA Recap</a></li></p>
+					<li><p>Lastest from the blog: <a href="https://blog.soliditylang.org/2020/09/18/meet-the-team/">Meet the Solidity team!</a> - short interviews with some of the core team members and <a href="https://blog.soliditylang.org/2020/11/04/solidity-ama-1-recap/">Solidity AMA Recap</a></li></p>
 				</p>
 				<div class="text editable">
 		</div>
@@ -83,7 +83,7 @@ contract MyContract {
 	<div class="container flex">
 		<div class="text editable">
 			<h2><strong>New to Solidity? Getting started is easy.</strong></h2>
-		<p class="editable">As a beginner, you find great tutorials, resources and tools that help you get started building with Solidity on the <a href="https://ethereum.org/en/developers/">ethereum.org developer portal</a>.<br><br>Alternatively, you can start by learning the basics about blockchain, smart contracts and the Ethereum Virtual Machine (EVM) in the <a href="https://solidity.readthedocs.io/en/latest/introduction-to-smart-contracts.html">Solidity docs</a>.</p>
+		<p class="editable">As a beginner, you find great tutorials, resources and tools that help you get started building with Solidity on the <a href="https://ethereum.org/en/developers/">ethereum.org developer portal</a>.<br><br>Alternatively, you can start by learning the basics about blockchain, smart contracts and the Ethereum Virtual Machine (EVM) in the <a href="https://docs.soliditylang.org/en/latest/introduction-to-smart-contracts.html">Solidity docs</a>.</p>
 	</div>
 </section>
 
@@ -91,7 +91,7 @@ contract MyContract {
 	<section>
 		<div class="container flex">
 			<div class="text editable">
-				<h2><strong><a href="https://solidity.readthedocs.io/en/latest/contributing.html">Contribute</a> towards enhancing Solidity by sharing your opinion in the language design discussions!</strong></h2><br>
+				<h2><strong><a href="https://docs.soliditylang.org/en/latest/contributing.html">Contribute</a> towards enhancing Solidity by sharing your opinion in the language design discussions!</strong></h2><br>
 				<p>We welcome Solidity power users, auditors, security experts and tooling developers to 
 					get involved and actively contribute to the Solidity language design process.</p>
 					<ul>
@@ -106,3 +106,19 @@ contract MyContract {
 		</div>
 	</section>
 </div>
+
+<section class="highlight-section-left">
+	<div class="container flex">
+		<div class="text editable">
+			<h2>The <strong><a href="https://summit.soliditylang.org">Solidity Summit</a></strong> is a free interactive forum for people involved and interested in the Solidity language and the ecosystem around it.</h2>
+			<p>The 1st Solidity Summit <a href="https://blog.soliditylang.org/2020/04/17/solidity-summit-2020-goes-interspace/">took place online</a> on April 29-30 2020 and featured discussions & talks on Solidity, Yul, language design and tooling. The event aimed to...</p>
+				<ul>
+					<li><p>Host useful (language design related) discussions that result in improvement proposals, leading to actual implementations.</p></li>
+					<li><p>Foster communication between teams working on similar topics.</p></li>
+					<li><p>Identify needs for the smart contract ecosystem for Ethereum.</p></li>
+				</ul>
+		<p>There will be more Solidity Summits (tbd whether in-person or online) coming up in future. In the meantime, you can revisit the 2020 <a href="https://docs.google.com/spreadsheets/d/1ylkaTYKx9TbAifCgyH2jN9SKJKrYfzab9zzTZgSL44g">agenda</a>, watch the <a href="https://www.youtube.com/watch?v=lhjo2FuU4v0&list=PLaM7G4Llrb7xlGxwlYGTy1T-GHpytE3RC">talks</a> online or read the <a href="https://blog.soliditylang.org/2020/06/09/solidity-summit-recap/">recap</a> of the event.</p>
+		<br>
+		{% include youtube.html youtube_id="lhjo2FuU4v0?start=575" %}
+		</div>
+</section>

--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@ contract MyContract {
 					<li><p>Foster communication between teams working on similar topics.</p></li>
 					<li><p>Identify needs for the smart contract ecosystem for Ethereum.</p></li>
 				</ul>
-		<p>There will be more Solidity Summits (tbd whether in-person or online) coming up in future. In the meantime, you can revisit the 2020 <a href="https://docs.google.com/spreadsheets/d/1ylkaTYKx9TbAifCgyH2jN9SKJKrYfzab9zzTZgSL44g">agenda</a>, watch the <a href="https://www.youtube.com/watch?v=lhjo2FuU4v0&list=PLaM7G4Llrb7xlGxwlYGTy1T-GHpytE3RC">talks</a> online or read the <a href="https://blog.soliditylang.org/2020/06/09/solidity-summit-recap/">recap</a> of the event.</p>
+		<p>There will be more Solidity Summits coming up in future. In the meantime, you can revisit the 2020 <a href="https://docs.google.com/spreadsheets/d/1ylkaTYKx9TbAifCgyH2jN9SKJKrYfzab9zzTZgSL44g">agenda</a>, watch the <a href="https://www.youtube.com/watch?v=lhjo2FuU4v0&list=PLaM7G4Llrb7xlGxwlYGTy1T-GHpytE3RC">talks</a> online or read the <a href="https://blog.soliditylang.org/2020/06/09/solidity-summit-recap/">recap</a> of the event.</p>
 		<br>
 		{% include youtube.html youtube_id="lhjo2FuU4v0?start=575" %}
 		</div>


### PR DESCRIPTION
- Adds section on the Solidity Summit (closes #7) 
- Adds YouTube embeds (which can now be easily embedded, responsive)
- Fixes links using old domains to soliditylang.org domain links