### PR TITLE
Update README to direct to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## 🚨 This repository has been archived. Please visit the new home for the Solidity website codebase at [`ethereum/solidity-website`](https://github.com/ethereum/solidity-website)
+
 # Solidity Language Portal
 
 The Solidity Language Portal is based on the [Hydra template](https://learn.cloudcannon.com/templates/hydra/) for Jekyll.


### PR DESCRIPTION
Updates the README noting the repo has been archived, and directs users to the new repo.

The [new site](https://soliditylang.org) is live (🎉), so with this PR this repo can safely be archived and made read-only.

New repo at [ethereum/solidity-website](https://github.com/ethereum/solidity-website)